### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/ice-wzl/light_house/security/code-scanning/7](https://github.com/ice-wzl/light_house/security/code-scanning/7)

To fix this problem, we should add a `permissions` block at the root workflow level of `.github/workflows/pylint.yml` (just after the workflow name and before/on the `on:` trigger) to limit the default permissions for all jobs. The most restrictive and sufficient permission for these jobs is `contents: read`, which allows checking out code but does not permit write actions. Adding this block ensures the workflow follows the principle of least privilege and is future-proof to repository or organization changes. No other changes or imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
