### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,8 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ice-wzl/light_house/security/code-scanning/5](https://github.com/ice-wzl/light_house/security/code-scanning/5)

To fix the issue, you should add an explicit `permissions` block at the workflow level in `.github/workflows/pylint.yml` to set the least privilege needed. In this case, both jobs in the workflow only require read access to the repository contents, so the minimal permission block should be:

```yaml
permissions:
  contents: read
```

This block should be added above the `jobs:` block (after the `on:` block) to apply to all jobs in the workflow, unless a more specific `permissions` block is set within a job (which is not needed here). No other changes are required, and this will not affect existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
