### PR TITLE
Potential fix for code scanning alert no. 8: Disabled TLS certificate check

### DIFF
--- a/agent/agent_helper/checkin_helper.go
+++ b/agent/agent_helper/checkin_helper.go
@@ -43,7 +43,7 @@ type ResultsCreate struct {
 
 var CustomClient = &http.Client{
 	Transport: &http.Transport{
-		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig:   &tls.Config{},
 		DisableKeepAlives: true,
 	},
 	Timeout: 10 * time.Second,


### PR DESCRIPTION
Potential fix for [https://github.com/ice-wzl/light_house/security/code-scanning/8](https://github.com/ice-wzl/light_house/security/code-scanning/8)

To fix this problem, you should ensure that TLS certificates are always verified by removing `InsecureSkipVerify: true` from the `tls.Config` for `CustomClient`. The best fix, given the information available, is to omit the `InsecureSkipVerify` field entirely (it defaults to `false`), thereby enforcing proper certificate verification for HTTPS requests. If you have a legitimate reason for custom verification (e.g., using a custom CA), then you must configure the `RootCAs` properly rather than skipping verification.

In the given snippet (lines 44–50), update the client initialization so that `InsecureSkipVerify` is not set to `true` in the `tls.Config`. The rest of the client's configuration can remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
